### PR TITLE
List family config package as a dependency

### DIFF
--- a/cmd/provider-list/converter.go
+++ b/cmd/provider-list/converter.go
@@ -29,9 +29,8 @@ var SSOPNames = map[string]struct{}{}
 
 // GetSSOPNameFromManagedResource collects the new provider name from MR
 func GetSSOPNameFromManagedResource(u migration.UnstructuredWithMetadata) error {
-	newProviderName := getProviderAndServiceName(u.Object.GroupVersionKind().Group)
-	if newProviderName != "" {
-		SSOPNames[newProviderName] = struct{}{}
+	for _, pn := range getProviderAndServiceName(u.Object.GroupVersionKind().Group) {
+		SSOPNames[pn] = struct{}{}
 	}
 	return nil
 }
@@ -47,15 +46,14 @@ func GetSSOPNameFromComposition(u migration.UnstructuredWithMetadata) error {
 		if err != nil {
 			return errors.Wrap(err, "resource raw cannot convert to unstructured")
 		}
-		newProviderName := getProviderAndServiceName(composedUnstructured.GroupVersionKind().Group)
-		if newProviderName != "" {
-			SSOPNames[newProviderName] = struct{}{}
+		for _, pn := range getProviderAndServiceName(composedUnstructured.GroupVersionKind().Group) {
+			SSOPNames[pn] = struct{}{}
 		}
 	}
 	return nil
 }
 
-func getProviderAndServiceName(name string) string {
+func getProviderAndServiceName(name string) []string {
 	parts := strings.Split(name, ".")
 	if len(parts) > 3 {
 		provider := ""
@@ -67,10 +65,10 @@ func getProviderAndServiceName(name string) string {
 		case "azure":
 			provider = "provider-azure"
 		default:
-			return ""
+			return nil
 		}
 		service := parts[0]
-		return fmt.Sprintf("%s-%s", provider, service)
+		return []string{fmt.Sprintf("%s-%s", provider, service), fmt.Sprintf("provider-family-%s", parts[1])}
 	}
-	return ""
+	return nil
 }

--- a/cmd/provider-list/converter_test.go
+++ b/cmd/provider-list/converter_test.go
@@ -97,7 +97,8 @@ func TestGetSSOPNameFromManagedResource(t *testing.T) {
 			},
 			want: want{
 				ssopMap: map[string]struct{}{
-					"provider-aws-ec2": {},
+					"provider-aws-ec2":    {},
+					"provider-family-aws": {},
 				},
 				err: nil,
 			},
@@ -126,6 +127,7 @@ func TestGetSSOPNameFromManagedResource(t *testing.T) {
 			want: want{
 				ssopMap: map[string]struct{}{
 					"provider-azure-network": {},
+					"provider-family-azure":  {},
 				},
 				err: nil,
 			},
@@ -153,6 +155,7 @@ func TestGetSSOPNameFromManagedResource(t *testing.T) {
 			},
 			want: want{
 				ssopMap: map[string]struct{}{
+					"provider-family-gcp":  {},
 					"provider-gcp-network": {},
 				},
 				err: nil,

--- a/cmd/provider-list/main.go
+++ b/cmd/provider-list/main.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 
 	"github.com/alecthomas/kong"
@@ -35,7 +36,12 @@ import (
 )
 
 const (
-	defaultKubeConfig = ".kube/config"
+	defaultKubeConfig          = ".kube/config"
+	commentFamilyConfigPackage = " # automatically installed as a dependency of the family packages"
+)
+
+var (
+	regexFamilyConfigPackageName = regexp.MustCompile(`^provider-family-(aws|azure|gcp)$`)
 )
 
 // Options represents the available subcommands of provider-list:
@@ -87,7 +93,11 @@ func main() {
 	sort.Strings(providers)
 	logger := log.New(os.Stdout, "", 0)
 	for _, p := range providers {
-		logger.Printf("%s", fmt.Sprintf("%s/%s:%s", opts.RegistryOrg, p, opts.Version))
+		packageComment := ""
+		if regexFamilyConfigPackageName.MatchString(p) {
+			packageComment = commentFamilyConfigPackage
+		}
+		logger.Printf("%s", fmt.Sprintf("%s/%s:%s%s", opts.RegistryOrg, p, opts.Version, packageComment))
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve extensions-migration!

Please read through https://git.io/fj2m9 if this is your first time opening an
extensions-migration pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open extensions-migration issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We now list family config packages as a dependency with the following comment:
```shell
# automatically installed as a dependency of the family packages
```

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested against `upbound/platform-ref-gcp` source and produces the following output:
```shell
>  provider-list local --path ~/upbound/platform-ref-gcp/package --family-version v0.37.0

xpkg.upbound.io/upbound/provider-family-gcp:v0.37.0 # automatically installed as a dependency of the family packages
xpkg.upbound.io/upbound/provider-gcp-cloudplatform:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-compute:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-container:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-servicenetworking:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-sql:v0.37.0
```

Also tested against a local kind cluster:
```shell
❯ provider-list cluster --family-version v0.37.0

xpkg.upbound.io/upbound/provider-aws-rds:v0.37.0
xpkg.upbound.io/upbound/provider-family-aws:v0.37.0 # automatically installed as a dependency of the family packages
xpkg.upbound.io/upbound/provider-family-gcp:v0.37.0 # automatically installed as a dependency of the family packages
xpkg.upbound.io/upbound/provider-gcp-cloudplatform:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-compute:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-servicenetworking:v0.37.0
xpkg.upbound.io/upbound/provider-gcp-sql:v0.37.0
```