### PR TITLE
Improve the dry run experience

### DIFF
--- a/cmd/family-migrator/main.go
+++ b/cmd/family-migrator/main.go
@@ -337,10 +337,13 @@ func askExecutionSteps(kongCtx *kong.Context, plan *migration.Plan, opts *Option
 	}
 	kongCtx.FatalIfErrorf(survey.AskOne(manualExecutionSteps, &displaySteps))
 	if displaySteps {
-		for _, s := range plan.Spec.Steps {
+		for i, s := range plan.Spec.Steps {
+			buff := strings.Builder{}
+			buff.WriteString(fmt.Sprintf("%d. %s: %s\n", i+1, s.Name, s.Description))
 			for _, c := range s.ManualExecution {
-				fmt.Println(c)
+				buff.WriteString(fmt.Sprintf("$ %s \n", c))
 			}
+			fmt.Println(buff.String())
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -89,3 +89,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/upbound/upjet => ../upjet

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/upbound/upjet v0.9.0-rc.0.0.20230707151127-90af5e54611a h1:D0E7zn1NCZv9fiDgnG9p9wI4IV7kZYNMugt3xUlWutw=
-github.com/upbound/upjet v0.9.0-rc.0.0.20230707151127-90af5e54611a/go.mod h1:3wLiq0eRZ+o6i6TWvELJ0jHv3pSnHk7r/zC2zFRDif8=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=


### PR DESCRIPTION
### Description of your changes

Depends on: https://github.com/upbound/upjet/pull/235

This PR adds names and descriptions of steps to the instruction list.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```bash
1. backup-managed-resources: Backing up Managed Resources
$ sh -c "kubectl get managed -o yaml > backup/managed-resources.yaml" 

2. backup-composite-resources: Backing up Composite Resources
$ sh -c "kubectl get composite -o yaml > backup/composite-resources.yaml" 

3. backup-claim-resources: Backing up Claims
$ sh -c "kubectl get claim --all-namespaces -o yaml > backup/claim-resources.yaml" 

4. new-ssop: Installing the new family provider
$ kubectl apply -f new-ssop/upbound-provider-family-gcp.providers.pkg.crossplane.io_v1.yaml 

5. wait-for-healthy: Checking health of new family provider
$ sh -c "kubectl wait provider.pkg upbound-provider-family-gcp --for condition=Healthy" 

6. new-ssop: Installing the new service scoped providers
$ kubectl apply -f new-ssop/upbound-provider-gcp-container.providers.pkg.crossplane.io_v1.yaml 
$ kubectl apply -f new-ssop/upbound-provider-gcp-compute.providers.pkg.crossplane.io_v1.yaml 
$ kubectl apply -f new-ssop/upbound-provider-gcp-servicenetworking.providers.pkg.crossplane.io_v1.yaml 
$ kubectl apply -f new-ssop/upbound-provider-gcp-cloudplatform.providers.pkg.crossplane.io_v1.yaml 
$ kubectl apply -f new-ssop/upbound-provider-gcp-sql.providers.pkg.crossplane.io_v1.yaml 

7. wait-for-healthy: Checking health of new service scoped provider
$ sh -c "kubectl wait provider.pkg upbound-provider-gcp-container --for condition=Healthy" 

8. wait-for-healthy: Checking health of new service scoped provider
$ sh -c "kubectl wait provider.pkg upbound-provider-gcp-compute --for condition=Healthy" 

9. wait-for-healthy: Checking health of new service scoped provider
$ sh -c "kubectl wait provider.pkg upbound-provider-gcp-servicenetworking --for condition=Healthy" 

10. wait-for-healthy: Checking health of new service scoped provider
$ sh -c "kubectl wait provider.pkg upbound-provider-gcp-cloudplatform --for condition=Healthy" 

11. wait-for-healthy: Checking health of new service scoped provider
$ sh -c "kubectl wait provider.pkg upbound-provider-gcp-sql --for condition=Healthy" 

12. edit-package-lock: Deleting configuration package dependency from Lock resource
$ kubectl patch --type='merge' -f edit-package-lock/lock.locks.pkg.crossplane.io_v1beta1.yaml --patch-file edit-package-lock/lock.locks.pkg.crossplane.io_v1beta1.yaml 

13. delete-monolithic-provider: Deleting monolithic provider
$ kubectl delete Provider.pkg.crossplane.io upbound-provider-gcp 

14. activate-ssop: Activating the new family provider after deletion monolithic one
$ kubectl patch --type='merge' -f activate-ssop/upbound-provider-family-gcp.providers.pkg.crossplane.io_v1.yaml --patch-file activate-ssop/upbound-provider-family-gcp.providers.pkg.crossplane.io_v1.yaml 

15. wait-for-installed: Checking installation of new family provider
$ sh -c "kubectl wait provider.pkg upbound-provider-family-gcp --for condition=Installed" 

16. activate-ssop: Activating the new service scoped providers
$ kubectl patch --type='merge' -f activate-ssop/upbound-provider-gcp-container.providers.pkg.crossplane.io_v1.yaml --patch-file activate-ssop/upbound-provider-gcp-container.providers.pkg.crossplane.io_v1.yaml 
$ kubectl patch --type='merge' -f activate-ssop/upbound-provider-gcp-compute.providers.pkg.crossplane.io_v1.yaml --patch-file activate-ssop/upbound-provider-gcp-compute.providers.pkg.crossplane.io_v1.yaml 
$ kubectl patch --type='merge' -f activate-ssop/upbound-provider-gcp-servicenetworking.providers.pkg.crossplane.io_v1.yaml --patch-file activate-ssop/upbound-provider-gcp-servicenetworking.providers.pkg.crossplane.io_v1.yaml 
$ kubectl patch --type='merge' -f activate-ssop/upbound-provider-gcp-cloudplatform.providers.pkg.crossplane.io_v1.yaml --patch-file activate-ssop/upbound-provider-gcp-cloudplatform.providers.pkg.crossplane.io_v1.yaml 
$ kubectl patch --type='merge' -f activate-ssop/upbound-provider-gcp-sql.providers.pkg.crossplane.io_v1.yaml --patch-file activate-ssop/upbound-provider-gcp-sql.providers.pkg.crossplane.io_v1.yaml 

17. wait-for-installed: Checking installation of new service scoped provider
$ sh -c "kubectl wait provider.pkg upbound-provider-gcp-container --for condition=Installed" 

18. wait-for-installed: Checking installation of new service scoped provider
$ sh -c "kubectl wait provider.pkg upbound-provider-gcp-compute --for condition=Installed" 

19. wait-for-installed: Checking installation of new service scoped provider
$ sh -c "kubectl wait provider.pkg upbound-provider-gcp-servicenetworking --for condition=Installed" 

20. wait-for-installed: Checking installation of new service scoped provider
$ sh -c "kubectl wait provider.pkg upbound-provider-gcp-cloudplatform --for condition=Installed" 

21. wait-for-installed: Checking installation of new service scoped provider
$ sh -c "kubectl wait provider.pkg upbound-provider-gcp-sql --for condition=Installed" 

22. edit-configuration-metadata: Editing the Configuration Meta resource with new family provider references
$ sh -c "cp edit-configuration-metadata/platform-ref-gcp.configurations.meta.pkg.crossplane.io_v1alpha1.yaml /Users/sergenyalcin/workspace/upbound/platform-ref-gcp/package/crossplane.yaml" 

23. build-configuration: Building the new configuration pkg
$ sh -c "up xpkg build --package-root=/Users/sergenyalcin/workspace/upbound/platform-ref-gcp/package --examples-root=/Users/sergenyalcin/workspace/upbound/platform-ref-gcp/examples -o /tmp/generated/update-conf.pkg" 

24. push-configuration: Pushing the new configuration pkg
$ sh -c "up xpkg push index.docker.io/sergenyalcin10/platform-ref-gcp:v0.3.0-migrated -f /tmp/generated/update-conf.pkg" 
```
