### PR TITLE
Bump build submodule to commit bd5297bd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ PLATFORMS ?= linux_amd64 linux_arm64 darwin_amd64 darwin_arm64
 # ====================================================================================
 # Setup Go
 GO_REQUIRED_VERSION = 1.19
-GOLANGCILINT_VERSION ?= 1.50.0
+# GOLANGCILINT_VERSION is inherited from build submodule by default.
+# Uncomment below if you need to override the version.
+# GOLANGCILINT_VERSION ?= 1.53.3
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider-list $(GO_PROJECT)/cmd/family-migrator
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
 GO_SUBDIRS += cmd internal


### PR DESCRIPTION
<!--
Thank you for helping to improve extensions-migration!

Please read through https://git.io/fj2m9 if this is your first time opening an
extensions-migration pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open extensions-migration issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Related PR: https://github.com/upbound/provider-azure/pull/510
To unblock: https://github.com/upbound/extensions-migration/pull/22

This PR proposes not to override the GOLANGCILINT_VERSION make variable to consume the version declared in the build submodule and bumps the build submodule version.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
`make reviewable`