### PR TITLE
Add skip gvk option and output path for generated manifests

### DIFF
--- a/converters/template/examples/skipgvk.yaml
+++ b/converters/template/examples/skipgvk.yaml
@@ -1,0 +1,6 @@
+- group:   tf.upbound.io
+  version: v1beta1
+  kind:    Workspace
+- group: test.extensions.com
+  version: v1alpha1
+  kind: Resource

--- a/converters/template/go.mod
+++ b/converters/template/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/upbound/extensions-migration v0.1.0-rc.1.0.20230815112541-eb63a5c5393e
 	github.com/upbound/extensions-migration/converters/provider-aws v0.0.0-20230815094445-f6499b966d7f
 	github.com/upbound/provider-aws v0.38.0
-	github.com/upbound/upjet v0.10.0-rc.0.0.20230815092629-6e0d116c3666
+	github.com/upbound/upjet v0.11.0-rc.0.0.20230831202621-14cd59c9986d
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.27.3
-	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -128,7 +128,6 @@ require (
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.27.3 // indirect
 	k8s.io/apiextensions-apiserver v0.27.3 // indirect
 	k8s.io/cli-runtime v0.26.3 // indirect
@@ -143,6 +142,7 @@ require (
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace github.com/upbound/extensions-migration => ../../../extensions-migration

--- a/converters/template/go.sum
+++ b/converters/template/go.sum
@@ -411,8 +411,8 @@ github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uL
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/upbound/provider-aws v0.38.0 h1:7e3djbXpm92tuVTWa83wue8/P3SyyBRUqpVGLSTxW2s=
 github.com/upbound/provider-aws v0.38.0/go.mod h1:3ghjoDmZKHcJp9Z1Ssz0Mb1k6Sx0yF4cj8qx/xILIrw=
-github.com/upbound/upjet v0.10.0-rc.0.0.20230815092629-6e0d116c3666 h1:hckZ5EDqoIEi7OKlQGgdF2TkNSApBUdM5cYjOeQlvYU=
-github.com/upbound/upjet v0.10.0-rc.0.0.20230815092629-6e0d116c3666/go.mod h1:2RXHgpIugCL/S/Use1QJAeVaev901RBeUByQh5gUtGk=
+github.com/upbound/upjet v0.11.0-rc.0.0.20230831202621-14cd59c9986d h1:Ur4i0oFCd9LUDI0ErD58q3+AhSlpqzcQhQCRqJj4cKA=
+github.com/upbound/upjet v0.11.0-rc.0.0.20230831202621-14cd59c9986d/go.mod h1:2RXHgpIugCL/S/Use1QJAeVaev901RBeUByQh5gUtGk=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
### Description of your changes

Depends on https://github.com/upbound/upjet/pull/265

This PR adds:

- Skip gvk option
- Output path for generated manifests

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested in the migrator template
