### PR TITLE
Update handling of SQS Queues

### DIFF
--- a/converters/provider-aws/sqs/queue.go
+++ b/converters/provider-aws/sqs/queue.go
@@ -60,7 +60,7 @@ func QueueResource(mg resource.Managed) ([]resource.Managed, error) {
 
 	if source.Spec.ForProvider.RedrivePolicy != nil {
 		RedrivePolicyData := map[string]interface{}{
-			"deadLetterTargetArn": source.Spec.ForProvider.RedrivePolicy.DeadLetterTargetARNRef.Name,
+			"deadLetterTargetArn": source.Spec.ForProvider.RedrivePolicy.DeadLetterTargetARN,
 			"maxReceiveCount":     source.Spec.ForProvider.RedrivePolicy.MaxReceiveCount,
 		}
 

--- a/converters/provider-aws/sqs/queue.go
+++ b/converters/provider-aws/sqs/queue.go
@@ -27,14 +27,10 @@ import (
 func QueueResource(mg resource.Managed) ([]resource.Managed, error) {
 	source := mg.(*srcv1alpha1.Queue)
 	target := &targetv1beta1.Queue{}
-	if _, err := migration.CopyInto(source, target, targetv1beta1.Queue_GroupVersionKind, "spec.forProvider.tags"); err != nil {
+	if _, err := migration.CopyInto(source, target, targetv1beta1.Queue_GroupVersionKind, "spec.forProvider.redrivePolicy"); err != nil {
 		return nil, errors.Wrap(err, "failed to copy source into target")
 	}
-	m := make(map[string]string)
-	target.Spec.ForProvider.Tags = make(map[string]*string, len(source.Spec.ForProvider.Tags))
-	for k, v := range source.Spec.ForProvider.Tags {
-		m[k] = v
-	}
+
 	target.Spec.ForProvider.Region = &source.Spec.ForProvider.Region
 	if source.Spec.ForProvider.DelaySeconds != nil {
 		convert := float64(*source.Spec.ForProvider.DelaySeconds)
@@ -67,11 +63,13 @@ func QueueResource(mg resource.Managed) ([]resource.Managed, error) {
 			"deadLetterTargetArn": source.Spec.ForProvider.RedrivePolicy.DeadLetterTargetARNRef.Name,
 			"maxReceiveCount":     source.Spec.ForProvider.RedrivePolicy.MaxReceiveCount,
 		}
+
 		RedrivePolicyDataJson, err := json.Marshal(RedrivePolicyData)
 		if err != nil {
-			convert := string(RedrivePolicyDataJson)
-			target.Spec.ForProvider.RedrivePolicy = &convert
+			return nil, errors.Wrap(err, "failed to parse redrive policy")
 		}
+		convert := string(RedrivePolicyDataJson)
+		target.Spec.ForProvider.RedrivePolicy = &convert
 	}
 
 	return []resource.Managed{


### PR DESCRIPTION
### Description of your changes

Update SQS Queue handling:

- tags can be handled by default
- fix `redrivePolicy` logic

I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

tested with the following manifest:
```
apiVersion: sqs.aws.crossplane.io/v1beta1
kind: Queue
metadata:
  labels:
    example.tech/infra-revision: "0.1.131"
    crossplane.io/provider-version: v0.42.0
  name: crossplane-official-provider-test
  namespace:
  annotations:
    argocd.argoproj.io/sync-wave: "5"
spec:
  forProvider:
    region: us-east-1
    delaySeconds: 10
    maximumMessageSize: 262144
    messageRetentionPeriod: 345600
    receiveMessageWaitTimeSeconds: 0
    visibilityTimeout: 30
    sseEnabled: true
    policy: |
      {
        "Version": "2012-10-17",
        "Id": "crossplane-official-provider-test-crossplane-official-provider-test",
        "Statement": [
          {
            "Sid": "BasicSQS",
            "Effect": "Allow",
            "Principal": "*",
            "Action": [
              "sqs:DeleteMessage",
              "sqs:SendMessage"
            ],
            "Resource": "arn:aws:sqs:us-east-1:1234567890:crossplane-official-provider-test",
            "Condition": {
              "StringLikeIfExists": {
                "aws:SourceAccount": "1234567890"
              }
            }
          }
        ]
      }
    redrivePolicy:
      deadLetterTargetArnRef:
       name: crossplane-official-provider-test-crossplane-official-provider-test-dlq
      maxReceiveCount: 10
    tags:
      App: crossplane-official-provider-test
      Environment: dev
      Name: crossplane-official-provider-test
      Tier: backend
      VS: sandbox
  providerConfigRef:
    name: awsconfig
```
